### PR TITLE
BER Tag Helper Function

### DIFF
--- a/encoding/tlv/ber.go
+++ b/encoding/tlv/ber.go
@@ -132,6 +132,7 @@ func (tv TagValue) MarshalBER() (buf []byte, err error) {
 	buf = append(buf, tb...)
 	buf = append(buf, lb...)
 	if cBuf != nil {
+		buf[0] |= 0x20
 		buf = append(buf, cBuf...)
 	} else {
 		buf = append(buf, tv.Value...)

--- a/encoding/tlv/ber.go
+++ b/encoding/tlv/ber.go
@@ -3,7 +3,10 @@
 
 package tlv
 
-import "errors"
+import (
+	"errors"
+	"math/bits"
+)
 
 var ErrNotConstructed = errors.New("tag is not constructed but contains children")
 
@@ -39,7 +42,12 @@ func NewBERTag(value uint, class Class) Tag {
 }
 
 func (t Tag) Class() Class {
-	return Class((t & 0xFF) >> 6)
+	bitLen := bits.Len(uint(t))
+	if bitLen%8 == 0 {
+		return Class(t >> (bitLen - 2))
+	}
+	alignedBitLen := (bitLen + 8 - (bitLen % 8))
+	return Class(t >> (alignedBitLen - 2))
 }
 
 func (t Tag) IsConstructed() bool {

--- a/encoding/tlv/ber.go
+++ b/encoding/tlv/ber.go
@@ -25,7 +25,7 @@ func NewBERTag(number uint, class Class) Tag {
 	var tag uint
 
 	if number < 0x1F {
-		return Tag(number | (uint(class) >> 6))
+		return Tag(number | (uint(class) << 6))
 	}
 
 	tag = 0x1F | (uint(class) << 6)

--- a/encoding/tlv/ber.go
+++ b/encoding/tlv/ber.go
@@ -21,22 +21,22 @@ const (
 
 // NewBERTag creates a new ASN.1 BER-TLV encoded tag field from a value and class
 // See: ISO 7816-4 Section 5.2.2.1 BER-TLV tag fields
-func NewBERTag(value uint, class Class) Tag {
+func NewBERTag(number uint, class Class) Tag {
 	var tag uint
 
-	if value < 0x1F {
-		return Tag(value | (uint(class) >> 6))
+	if number < 0x1F {
+		return Tag(number | (uint(class) >> 6))
 	}
 
 	tag = 0x1F | (uint(class) << 6)
-	if value < 0x7F {
-		return Tag(tag<<8 | value)
+	if number < 0x7F {
+		return Tag(tag<<8 | number)
 	}
-	if value < 0x3FFF {
-		return Tag((tag << 16) | (((value>>7)&0x7F | 0x80) << 8) | (value & 0x7F))
+	if number < 0x3FFF {
+		return Tag((tag << 16) | (((number>>7)&0x7F | 0x80) << 8) | (number & 0x7F))
 	}
-	if value < 0x1FFFFF {
-		return Tag((tag << 24) | (((value>>14)&0x7F | 0x80) << 16) | (((value>>7)&0x7F | 0x80) << 8) | (value & 0x7F))
+	if number < 0x1FFFFF {
+		return Tag((tag << 24) | (((number>>14)&0x7F | 0x80) << 16) | (((number>>7)&0x7F | 0x80) << 8) | (number & 0x7F))
 	}
 	return 0
 }

--- a/encoding/tlv/ber.go
+++ b/encoding/tlv/ber.go
@@ -16,6 +16,28 @@ const (
 	ClassPrivate     Class = 0b11
 )
 
+// NewBERTag creates a new ASN.1 BER-TLV encoded tag field from a value and class
+// See: ISO 7816-4 Section 5.2.2.1 BER-TLV tag fields
+func NewBERTag(value uint, class Class) Tag {
+	var tag uint
+
+	if value < 0x1F {
+		return Tag(value | (uint(class) >> 6))
+	}
+
+	tag = 0x1F | (uint(class) << 6)
+	if value < 0x7F {
+		return Tag(tag<<8 | value)
+	}
+	if value < 0x3FFF {
+		return Tag((tag << 16) | (((value>>7)&0x7F | 0x80) << 8) | (value & 0x7F))
+	}
+	if value < 0x1FFFFF {
+		return Tag((tag << 24) | (((value>>14)&0x7F | 0x80) << 16) | (((value>>7)&0x7F | 0x80) << 8) | (value & 0x7F))
+	}
+	return 0
+}
+
 func (t Tag) Class() Class {
 	return Class((t & 0xFF) >> 6)
 }

--- a/encoding/tlv/ber_test.go
+++ b/encoding/tlv/ber_test.go
@@ -74,9 +74,14 @@ func TestEncodeNestedBER(t *testing.T) {
 	require := require.New(t)
 
 	expected := []byte{0x21, 0x09, 0x02, 0x02, 0x03, 0x04, 0x03, 0x03, 0x05, 0x06, 0x07}
+	expected = append(expected, 0x3F, 0x33, 0x09, 0x02, 0x02, 0x03, 0x04, 0x03, 0x03, 0x05, 0x06, 0x07)
 
 	buf, err := tlv.EncodeBER(
-		tlv.New(0x21,
+		tlv.New(0x01,
+			tlv.New(0x2, []byte{3, 4}),
+			tlv.New(0x3, []byte{5, 6, 7}),
+		),
+		tlv.New(tlv.NewBERTag(0x33, tlv.ClassUniversal),
 			tlv.New(0x2, []byte{3, 4}),
 			tlv.New(0x3, []byte{5, 6, 7}),
 		),
@@ -87,7 +92,11 @@ func TestEncodeNestedBER(t *testing.T) {
 	tvs, err := tlv.DecodeBER(buf)
 	require.NoError(err)
 	require.True(tvs.Equal(tlv.TagValues{
-		tlv.New(0x21,
+		tlv.New(0x21, // Still supports manually setting the constructed bit
+			tlv.New(0x2, []byte{3, 4}),
+			tlv.New(0x3, []byte{5, 6, 7}),
+		),
+		tlv.New(tlv.NewBERTag(0x33, tlv.ClassContext),
 			tlv.New(0x2, []byte{3, 4}),
 			tlv.New(0x3, []byte{5, 6, 7}),
 		),

--- a/encoding/tlv/ber_test.go
+++ b/encoding/tlv/ber_test.go
@@ -19,6 +19,9 @@ func TestTagBER(t *testing.T) {
 		class       tlv.Class
 		constructed bool
 	}{
+		{tlv.NewBERTag(0x20, tlv.ClassUniversal), tlv.ClassUniversal, false},
+		{tlv.NewBERTag(0x200, tlv.ClassContext), tlv.ClassContext, false},
+		{tlv.NewBERTag(0x20000, tlv.ClassPrivate), tlv.ClassPrivate, false},
 		{0x21, tlv.ClassUniversal, true},
 		{0x01, tlv.ClassUniversal, false},
 		{0x41, tlv.ClassApplication, false},
@@ -44,12 +47,14 @@ func TestEncodeBER(t *testing.T) {
 	expected = append(expected, 0x03, 0x82, 0x01, 0o0)
 	expected = append(expected, long2...)
 	expected = append(expected, 0x08, 0x03, 0x20, 0x21, 0x22)
+	expected = append(expected, 0x1f, 0x82, 0x00, 0x01, 0x20)
 
 	buf, err := tlv.EncodeBER(
 		tlv.New(0x1, []byte{0x10, 0x11, 0x12, 0x13}),
 		tlv.New(0x2, long1),
 		tlv.New(0x3, long2),
 		tlv.New(0x8, []byte{0x20, 0x21, 0x22}),
+		tlv.New(tlv.NewBERTag(0x100, tlv.ClassUniversal), []byte{0x20}),
 	)
 	require.NoError(err)
 	require.Equal(expected, buf)
@@ -61,6 +66,7 @@ func TestEncodeBER(t *testing.T) {
 		tlv.New(0x2, long1),
 		tlv.New(0x3, long2),
 		tlv.New(0x8, []byte{0x20, 0x21, 0x22}),
+		tlv.New(tlv.NewBERTag(0x100, tlv.ClassUniversal), []byte{0x20}),
 	}, tvs)
 }
 

--- a/encoding/tlv/ber_test.go
+++ b/encoding/tlv/ber_test.go
@@ -19,6 +19,7 @@ func TestTagBER(t *testing.T) {
 		class       tlv.Class
 		constructed bool
 	}{
+		{tlv.NewBERTag(0x2, tlv.ClassContext), tlv.ClassContext, false},
 		{tlv.NewBERTag(0x20, tlv.ClassUniversal), tlv.ClassUniversal, false},
 		{tlv.NewBERTag(0x200, tlv.ClassContext), tlv.ClassContext, false},
 		{tlv.NewBERTag(0x20000, tlv.ClassPrivate), tlv.ClassPrivate, false},

--- a/encoding/tlv/ber_test.go
+++ b/encoding/tlv/ber_test.go
@@ -74,10 +74,15 @@ func TestEncodeNestedBER(t *testing.T) {
 	require := require.New(t)
 
 	expected := []byte{0x21, 0x09, 0x02, 0x02, 0x03, 0x04, 0x03, 0x03, 0x05, 0x06, 0x07}
+	expected = append(expected, 0x21, 0x09, 0x02, 0x02, 0x03, 0x04, 0x03, 0x03, 0x05, 0x06, 0x07)
 	expected = append(expected, 0x3F, 0x33, 0x09, 0x02, 0x02, 0x03, 0x04, 0x03, 0x03, 0x05, 0x06, 0x07)
 
 	buf, err := tlv.EncodeBER(
 		tlv.New(0x01,
+			tlv.New(0x2, []byte{3, 4}),
+			tlv.New(0x3, []byte{5, 6, 7}),
+		),
+		tlv.New(0x21, // Test manually setting the constructed bit
 			tlv.New(0x2, []byte{3, 4}),
 			tlv.New(0x3, []byte{5, 6, 7}),
 		),
@@ -92,7 +97,11 @@ func TestEncodeNestedBER(t *testing.T) {
 	tvs, err := tlv.DecodeBER(buf)
 	require.NoError(err)
 	require.True(tvs.Equal(tlv.TagValues{
-		tlv.New(0x21, // Still supports manually setting the constructed bit
+		tlv.New(0x21,
+			tlv.New(0x2, []byte{3, 4}),
+			tlv.New(0x3, []byte{5, 6, 7}),
+		),
+		tlv.New(0x21,
 			tlv.New(0x2, []byte{3, 4}),
 			tlv.New(0x3, []byte{5, 6, 7}),
 		),


### PR DESCRIPTION
This PR adds a helper function to create new ANS.1 BER standard tags using the number and class of the tag: 
```go 
NewBERTag(number uint, class Class) Tag
```

#### Additionally
 - Updated the `Class()` method to support tags longer than 1 byte
 - Constructed bit is set in `EncodeBER()` for TLVs with child TLVs
