### PR TITLE
Add method to get a BER encoded tag's number

### DIFF
--- a/encoding/tlv/ber.go
+++ b/encoding/tlv/ber.go
@@ -50,6 +50,31 @@ func (t Tag) Class() Class {
 	return Class(t >> (alignedBitLen - 2))
 }
 
+// Returns the BER encoded number of the tag
+func (t Tag) BERNumber() uint {
+	bitLen := bits.Len(uint(t))
+	var byteLen int
+	if bitLen%8 == 0 {
+		byteLen = bitLen / 8
+	} else {
+		byteLen = (bitLen + 8 - (bitLen % 8)) / 8
+	}
+	switch byteLen {
+	case 0:
+		return 0
+	case 1:
+		return uint(t) & 0x1F
+	case 2:
+		return uint(t) & 0x7F
+	case 3:
+		return ((uint(t) & (0x7F << 8)) >> 1) | (uint(t) & 0x7F)
+	case 4:
+		return ((uint(t) & (0x7F << 16)) >> 2) | ((uint(t) & (0x7F << 8)) >> 1) | (uint(t) & 0x7F)
+	default:
+		return 0
+	}
+}
+
 func (t Tag) IsConstructed() bool {
 	u := t
 	for u > 0xFF {

--- a/encoding/tlv/ber_test.go
+++ b/encoding/tlv/ber_test.go
@@ -16,21 +16,23 @@ func TestTagBER(t *testing.T) {
 
 	cases := []struct {
 		tag         tlv.Tag
+		number      uint
 		class       tlv.Class
 		constructed bool
 	}{
-		{tlv.NewBERTag(0x2, tlv.ClassContext), tlv.ClassContext, false},
-		{tlv.NewBERTag(0x20, tlv.ClassUniversal), tlv.ClassUniversal, false},
-		{tlv.NewBERTag(0x200, tlv.ClassContext), tlv.ClassContext, false},
-		{tlv.NewBERTag(0x20000, tlv.ClassPrivate), tlv.ClassPrivate, false},
-		{0x21, tlv.ClassUniversal, true},
-		{0x01, tlv.ClassUniversal, false},
-		{0x41, tlv.ClassApplication, false},
-		{0x81, tlv.ClassContext, false},
-		{0xC1, tlv.ClassPrivate, false},
+		{tlv.NewBERTag(0x2, tlv.ClassContext), 0x2, tlv.ClassContext, false},
+		{tlv.NewBERTag(0x20, tlv.ClassUniversal), 0x20, tlv.ClassUniversal, false},
+		{tlv.NewBERTag(0x200, tlv.ClassContext), 0x200, tlv.ClassContext, false},
+		{tlv.NewBERTag(0x20000, tlv.ClassPrivate), 0x20000, tlv.ClassPrivate, false},
+		{0x21, 0x01, tlv.ClassUniversal, true},
+		{0x01, 0x01, tlv.ClassUniversal, false},
+		{0x41, 0x01, tlv.ClassApplication, false},
+		{0x81, 0x01, tlv.ClassContext, false},
+		{0xC1, 0x01, tlv.ClassPrivate, false},
 	}
 
 	for _, c := range cases {
+		require.Equal(c.number, c.tag.BERNumber())
 		require.Equal(c.class, c.tag.Class())
 		require.Equal(c.constructed, c.tag.IsConstructed())
 	}


### PR DESCRIPTION
Hello, this commit adds a method to get the tag number from a BER encoded tag, and modifies the tag test to include the new method.

Let me know what you think :)
